### PR TITLE
feat: wire deposit/withdraw transactions + devnet onboarding

### DIFF
--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -10,8 +10,12 @@ export default function AppLayout({
   return (
     <SolanaProvider>
       <ToastProvider>
+        {/* Devnet banner — fixed above nav */}
+        <div className="fixed inset-x-0 top-0 z-[60] bg-amber-500/10 border-b border-amber-500/20 text-amber-400 text-xs font-mono text-center py-1.5">
+          ⚠ Devnet Mode — Transactions use test USDC, not real funds
+        </div>
         <Nav />
-        <main className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-20">
+        <main className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 pt-28 pb-20">
           {children}
         </main>
       </ToastProvider>

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Nav } from '@/components/app/nav'
 import { SolanaProvider } from '@/providers/solana-provider'
+import { ToastProvider } from '@/components/ui/toast'
 
 export default function AppLayout({
   children,
@@ -8,10 +9,12 @@ export default function AppLayout({
 }) {
   return (
     <SolanaProvider>
-      <Nav />
-      <main className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-20">
-        {children}
-      </main>
+      <ToastProvider>
+        <Nav />
+        <main className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-20">
+          {children}
+        </main>
+      </ToastProvider>
     </SolanaProvider>
   )
 }

--- a/src/app/app/vaults/[riskLevel]/page.tsx
+++ b/src/app/app/vaults/[riskLevel]/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
-import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { ArrowLeft, ArrowRight, ExternalLink } from 'lucide-react'
 import { GlassCard } from '@/components/ui/glass-card'
 import { Badge } from '@/components/ui/badge'
 import { YieldChart } from '@/components/app/yield-chart'
@@ -241,7 +241,7 @@ function VaultDetailContent({
         </div>
 
         {/* Right Column (sticky) */}
-        <div className="col-span-5 space-y-6 mt-8 lg:mt-0 sticky top-28">
+        <div className="col-span-5 space-y-6 mt-8 lg:mt-0 sticky top-36">
           {/* Deposit Form */}
           <DepositForm
             riskLevel={riskLevel}
@@ -261,6 +261,43 @@ function VaultDetailContent({
 
           {/* Guardrail Card */}
           <GuardrailCard guardrails={guardrails} />
+
+          {/* Devnet Onboarding */}
+          <GlassCard className="p-5 bg-sky-500/5 border-sky-500/10">
+            <h3 className="text-sm font-semibold text-sky-400 mb-3">Getting Started on Devnet</h3>
+            <ol className="space-y-2.5 text-xs text-slate-400">
+              <li className="flex items-start gap-2">
+                <span className="text-sky-500 font-mono font-bold shrink-0">1.</span>
+                <span>
+                  <a
+                    href="https://faucet.solana.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sky-400 hover:text-sky-300 transition-colors inline-flex items-center gap-1"
+                  >
+                    Get devnet SOL
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                  {' — '}free from the Solana faucet
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-sky-500 font-mono font-bold shrink-0">2.</span>
+                <span>
+                  <span className="text-slate-300">Get test USDC</span>
+                  {' — '}contact the team for tokens
+                  <span className="block mt-0.5 font-mono text-[10px] text-slate-500">mint: BiTXT...DcFR</span>
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-sky-500 font-mono font-bold shrink-0">3.</span>
+                <span>
+                  <span className="text-slate-300">Connect Phantom</span>
+                  {' — '}switch to devnet in Settings → Developer Settings
+                </span>
+              </li>
+            </ol>
+          </GlassCard>
         </div>
       </div>
     </div>

--- a/src/app/app/vaults/[riskLevel]/page.tsx
+++ b/src/app/app/vaults/[riskLevel]/page.tsx
@@ -11,7 +11,7 @@ import { ProtocolBar } from '@/components/app/protocol-bar'
 import { GuardrailCard } from '@/components/app/guardrail-card'
 import { DecisionFeedItem } from '@/components/app/decision-feed-item'
 import { DepositForm } from '@/components/app/deposit-form'
-import { useRiskVault, useUsdcBalance } from '@/hooks/use-allocator'
+import { useRiskVault, useUserPosition, useUsdcBalance } from '@/hooks/use-allocator'
 import { useVaultData, useKeeperDecisions } from '@/hooks/use-keeper-api'
 import {
   mockVaults,
@@ -82,6 +82,7 @@ function VaultDetailContent({
 }) {
   // On-chain data
   const onChain = useRiskVault(riskLevelNum)
+  const userPosition = useUserPosition(riskLevelNum)
   const usdcBalance = useUsdcBalance()
 
   // Keeper API data
@@ -244,9 +245,18 @@ function VaultDetailContent({
           {/* Deposit Form */}
           <DepositForm
             riskLevel={riskLevel}
+            riskLevelNum={riskLevelNum}
             apy={apy}
             dailyEarnings={dailyEarnings}
             walletBalance={walletBalance}
+            shareMint={onChain.data?.shareMint}
+            userShares={userPosition.data?.shares}
+            redemptionPeriodSlots={onChain.data?.redemptionPeriodSlots}
+            onSuccess={() => {
+              onChain.refresh()
+              userPosition.refresh()
+              usdcBalance.refresh()
+            }}
           />
 
           {/* Guardrail Card */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,6 +83,38 @@ body {
   animation: routePath 6s cubic-bezier(0.4, 0, 0.2, 1) infinite 3s;
 }
 
+/* ---- Toast animations ---- */
+
+@keyframes toastIn {
+  0% { opacity: 0; transform: translateX(100%); }
+  100% { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes toastOut {
+  0% { opacity: 1; transform: translateX(0); }
+  100% { opacity: 0; transform: translateX(100%); }
+}
+
+.animate-toast-in {
+  animation: toastIn 0.25s ease-out forwards;
+}
+
+.animate-toast-out {
+  animation: toastOut 0.2s ease-in forwards;
+}
+
+/* ---- Spinner ---- */
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.animate-spin {
+  animation: spin 0.75s linear infinite;
+}
+
+/* ---- Marketing hero animations ---- */
+
 @keyframes corePulse {
   0% { opacity: 0.6; transform: translate(-50%, -50%) scale(0.95); }
   100% { opacity: 1; transform: translate(-50%, -50%) scale(1.05); }

--- a/src/components/app/deposit-form.tsx
+++ b/src/components/app/deposit-form.tsx
@@ -1,37 +1,173 @@
 'use client'
 
-import { useState } from 'react'
-import { ArrowRight } from 'lucide-react'
+import { useState, useCallback } from 'react'
+import { ArrowRight, Loader2 } from 'lucide-react'
+import { Transaction, type PublicKey } from '@solana/web3.js'
+import { useWallet } from '@solana/wallet-adapter-react'
+import { useConnection } from '@solana/wallet-adapter-react'
 import { GlassCard } from '@/components/ui/glass-card'
 import { AIContext } from '@/components/app/ai-context'
+import { useToast } from '@/components/ui/toast'
+import {
+  buildDepositInstruction,
+  buildRequestWithdrawInstruction,
+  buildWithdrawInstruction,
+} from '@/lib/transactions'
+import { parseAllocatorError } from '@/lib/errors'
 import type { RiskLevel } from '@/lib/mock-data'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
 
 interface DepositFormProps {
   riskLevel: RiskLevel
+  riskLevelNum: number
   apy: number
   dailyEarnings: number
   walletBalance?: number
+  shareMint?: PublicKey
+  userShares?: bigint
+  redemptionPeriodSlots?: bigint
+  onSuccess?: () => void
 }
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const USDC_DECIMALS = 6
+
+// ─── Component ──────────────────────────────────────────────────────────────
 
 export function DepositForm({
   riskLevel,
+  riskLevelNum,
   apy,
   dailyEarnings,
   walletBalance,
+  shareMint,
+  userShares,
+  redemptionPeriodSlots,
+  onSuccess,
 }: DepositFormProps) {
   const [mode, setMode] = useState<'deposit' | 'withdraw'>('deposit')
   const [amount, setAmount] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const { publicKey, sendTransaction } = useWallet()
+  const { connection } = useConnection()
+  const { toast } = useToast()
 
   const parsedAmount = Number(amount) || 0
   const estimatedDaily = parsedAmount > 0
     ? (parsedAmount * apy) / 365
     : dailyEarnings
 
+  const isWalletConnected = !!publicKey
+  const isShareMintReady = !!shareMint
+  const canDeposit = isWalletConnected && isShareMintReady && parsedAmount > 0 && !loading
+  const canWithdraw = isWalletConnected && parsedAmount > 0 && !loading
+
+  // ─── Handlers ─────────────────────────────────────────────────────────────
+
   function handleMax() {
-    if (walletBalance !== undefined && walletBalance > 0) {
+    if (mode === 'deposit' && walletBalance !== undefined && walletBalance > 0) {
       setAmount(String(walletBalance))
+    } else if (mode === 'withdraw' && userShares !== undefined && userShares > 0n) {
+      // Convert shares back to approximate USDC for display
+      // Share price ~1:1 at initialization, so shares / 1e6 gives USDC
+      setAmount(String(Number(userShares) / 10 ** USDC_DECIMALS))
     }
   }
+
+  const handleDeposit = useCallback(async () => {
+    if (!publicKey || !shareMint || parsedAmount <= 0) return
+
+    setLoading(true)
+    try {
+      const amountInSmallestUnit = BigInt(Math.round(parsedAmount * 10 ** USDC_DECIMALS))
+
+      const instruction = await buildDepositInstruction(
+        publicKey,
+        riskLevelNum,
+        amountInSmallestUnit,
+        shareMint,
+      )
+
+      const tx = new Transaction().add(instruction)
+      const signature = await sendTransaction(tx, connection)
+
+      toast('Confirming transaction...', 'info')
+      await connection.confirmTransaction(signature, 'confirmed')
+
+      toast('Deposit confirmed!', 'success')
+      setAmount('')
+      onSuccess?.()
+    } catch (err) {
+      const message = parseAllocatorError(err)
+      toast(message, 'error')
+    } finally {
+      setLoading(false)
+    }
+  }, [publicKey, shareMint, parsedAmount, riskLevelNum, sendTransaction, connection, toast, onSuccess])
+
+  const handleWithdraw = useCallback(async () => {
+    if (!publicKey || parsedAmount <= 0) return
+
+    setLoading(true)
+    try {
+      // Convert entered USDC amount to shares
+      // For simplicity, treat 1 share = 1 USDC smallest unit at 1:1 price
+      const sharesAmount = BigInt(Math.round(parsedAmount * 10 ** USDC_DECIMALS))
+
+      const requestIx = await buildRequestWithdrawInstruction(
+        publicKey,
+        riskLevelNum,
+        sharesAmount,
+      )
+
+      const tx = new Transaction().add(requestIx)
+
+      // If redemption period is 0 (devnet), chain the complete-withdraw instruction too
+      const isInstantRedemption = redemptionPeriodSlots === 0n
+      if (isInstantRedemption && shareMint) {
+        const withdrawIx = await buildWithdrawInstruction(
+          publicKey,
+          riskLevelNum,
+          shareMint,
+        )
+        tx.add(withdrawIx)
+      }
+
+      const signature = await sendTransaction(tx, connection)
+
+      toast('Confirming transaction...', 'info')
+      await connection.confirmTransaction(signature, 'confirmed')
+
+      if (isInstantRedemption && shareMint) {
+        toast('Withdrawal complete!', 'success')
+      } else {
+        toast('Withdrawal requested — complete after redemption period.', 'success')
+      }
+
+      setAmount('')
+      onSuccess?.()
+    } catch (err) {
+      const message = parseAllocatorError(err)
+      toast(message, 'error')
+    } finally {
+      setLoading(false)
+    }
+  }, [publicKey, parsedAmount, riskLevelNum, shareMint, redemptionPeriodSlots, sendTransaction, connection, toast, onSuccess])
+
+  function handleSubmit() {
+    if (mode === 'deposit') {
+      handleDeposit()
+    } else {
+      handleWithdraw()
+    }
+  }
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  const isDisabled = mode === 'deposit' ? !canDeposit : !canWithdraw
 
   return (
     <GlassCard className="p-6 relative overflow-hidden">
@@ -70,9 +206,14 @@ export function DepositForm({
       <div className="space-y-2 mb-5">
         <div className="flex items-center justify-between">
           <label className="text-sm text-slate-400">Amount</label>
-          {walletBalance !== undefined && (
+          {mode === 'deposit' && walletBalance !== undefined && (
             <span className="text-xs text-slate-500 font-mono">
               Balance: {walletBalance.toLocaleString('en-US', { maximumFractionDigits: 2 })} USDC
+            </span>
+          )}
+          {mode === 'withdraw' && userShares !== undefined && (
+            <span className="text-xs text-slate-500 font-mono">
+              Shares: {(Number(userShares) / 10 ** USDC_DECIMALS).toLocaleString('en-US', { maximumFractionDigits: 2 })}
             </span>
           )}
         </div>
@@ -88,13 +229,15 @@ export function DepositForm({
             placeholder="0.00"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
-            className="w-full bg-[#030407] border border-white/10 rounded-xl py-4 pl-12 pr-20 text-2xl font-mono text-white placeholder:text-slate-600 focus:border-sky-500/50 focus:ring-1 focus:ring-sky-500/50 focus:outline-none transition-all"
+            disabled={loading}
+            className="w-full bg-[#030407] border border-white/10 rounded-xl py-4 pl-12 pr-20 text-2xl font-mono text-white placeholder:text-slate-600 focus:border-sky-500/50 focus:ring-1 focus:ring-sky-500/50 focus:outline-none transition-all disabled:opacity-50"
           />
           {/* MAX button */}
           <button
             type="button"
             onClick={handleMax}
-            className="absolute right-3 top-1/2 -translate-y-1/2 bg-white/5 text-sky-400 font-mono text-xs px-2.5 py-1 rounded-md border border-white/5 hover:bg-white/10 transition-colors"
+            disabled={loading}
+            className="absolute right-3 top-1/2 -translate-y-1/2 bg-white/5 text-sky-400 font-mono text-xs px-2.5 py-1 rounded-md border border-white/5 hover:bg-white/10 transition-colors disabled:opacity-50"
           >
             MAX
           </button>
@@ -122,14 +265,38 @@ export function DepositForm({
         </div>
       </div>
 
+      {/* Wallet not connected hint */}
+      {!isWalletConnected && (
+        <p className="text-xs text-amber-400/80 text-center mb-3">
+          Connect your wallet to {mode === 'deposit' ? 'deposit' : 'withdraw'}
+        </p>
+      )}
+
+      {/* Share mint loading hint (deposit only) */}
+      {isWalletConnected && !isShareMintReady && mode === 'deposit' && (
+        <p className="text-xs text-slate-500 text-center mb-3">
+          Loading vault data...
+        </p>
+      )}
+
       {/* Submit button */}
       <button
         type="button"
-        disabled={parsedAmount <= 0}
+        onClick={handleSubmit}
+        disabled={isDisabled}
         className="w-full py-4 rounded-xl bg-sky-500/10 hover:bg-sky-500/20 text-sky-400 font-semibold text-lg border border-sky-500/30 shadow-[0_0_20px_rgba(14,165,233,0.15)] hover:shadow-[0_0_30px_rgba(14,165,233,0.3)] transition-all duration-200 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center gap-2"
       >
-        {mode === 'deposit' ? 'Confirm Deposit' : 'Confirm Withdrawal'}
-        <ArrowRight className="h-5 w-5" />
+        {loading ? (
+          <>
+            <Loader2 className="h-5 w-5 animate-spin" />
+            Processing...
+          </>
+        ) : (
+          <>
+            {mode === 'deposit' ? 'Confirm Deposit' : 'Confirm Withdrawal'}
+            <ArrowRight className="h-5 w-5" />
+          </>
+        )}
       </button>
 
       {/* AI Context */}

--- a/src/components/app/nav.tsx
+++ b/src/components/app/nav.tsx
@@ -28,7 +28,7 @@ export function Nav() {
   const { setVisible } = useWalletModal()
 
   return (
-    <nav className="fixed inset-x-0 top-0 z-50 h-16 bg-slate-900/80 backdrop-blur-xl border-b border-white/5">
+    <nav className="fixed inset-x-0 top-8 z-50 h-16 bg-slate-900/80 backdrop-blur-xl border-b border-white/5">
       <div className="mx-auto flex h-full max-w-[1440px] items-center justify-between px-4 sm:px-6 lg:px-8">
         {/* Left — Logo */}
         <Link href="/app" className="flex items-center gap-2.5">

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,143 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { X, CheckCircle2, XCircle, Info } from 'lucide-react'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type ToastType = 'success' | 'error' | 'info'
+
+interface Toast {
+  id: string
+  message: string
+  type: ToastType
+}
+
+interface ToastContextValue {
+  toast: (message: string, type?: ToastType) => void
+  dismiss: (id: string) => void
+}
+
+// ─── Context ────────────────────────────────────────────────────────────────
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used within <ToastProvider>')
+  return ctx
+}
+
+// ─── Provider ───────────────────────────────────────────────────────────────
+
+const AUTO_DISMISS_MS = 5_000
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+  const counterRef = useRef(0)
+
+  const dismiss = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  const toast = useCallback((message: string, type: ToastType = 'info') => {
+    const id = `toast-${++counterRef.current}-${Date.now()}`
+    setToasts(prev => [...prev, { id, message, type }])
+  }, [])
+
+  return (
+    <ToastContext value={{ toast, dismiss }}>
+      {children}
+      <ToastContainer toasts={toasts} dismiss={dismiss} />
+    </ToastContext>
+  )
+}
+
+// ─── Container ──────────────────────────────────────────────────────────────
+
+function ToastContainer({
+  toasts,
+  dismiss,
+}: {
+  toasts: Toast[]
+  dismiss: (id: string) => void
+}) {
+  return (
+    <div
+      aria-live="polite"
+      className="fixed bottom-6 right-6 z-50 flex flex-col gap-3 pointer-events-none"
+    >
+      {toasts.map(t => (
+        <ToastItem key={t.id} toast={t} dismiss={dismiss} />
+      ))}
+    </div>
+  )
+}
+
+// ─── Item ───────────────────────────────────────────────────────────────────
+
+const ICON_MAP: Record<ToastType, typeof CheckCircle2> = {
+  success: CheckCircle2,
+  error: XCircle,
+  info: Info,
+}
+
+const STYLE_MAP: Record<ToastType, string> = {
+  success: 'border-emerald-500/40 text-emerald-300',
+  error: 'border-red-500/40 text-red-300',
+  info: 'border-sky-500/40 text-sky-300',
+}
+
+function ToastItem({
+  toast: t,
+  dismiss,
+}: {
+  toast: Toast
+  dismiss: (id: string) => void
+}) {
+  const [exiting, setExiting] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => setExiting(true), AUTO_DISMISS_MS)
+    return () => clearTimeout(timerRef.current)
+  }, [])
+
+  // After exit animation completes, remove from state
+  function handleAnimationEnd() {
+    if (exiting) dismiss(t.id)
+  }
+
+  const Icon = ICON_MAP[t.type]
+
+  return (
+    <div
+      role="status"
+      onAnimationEnd={handleAnimationEnd}
+      className={[
+        'pointer-events-auto flex items-start gap-3 px-4 py-3 rounded-xl border backdrop-blur-xl bg-[#0a0c10]/90 shadow-lg max-w-sm',
+        STYLE_MAP[t.type],
+        exiting ? 'animate-toast-out' : 'animate-toast-in',
+      ].join(' ')}
+    >
+      <Icon className="h-5 w-5 shrink-0 mt-0.5" />
+      <p className="text-sm text-slate-200 leading-snug flex-1">{t.message}</p>
+      <button
+        type="button"
+        aria-label="Dismiss notification"
+        onClick={() => setExiting(true)}
+        className="shrink-0 text-slate-500 hover:text-slate-300 transition-colors"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  )
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -37,9 +37,23 @@ const ERROR_MAP: Record<number, string> = {
  * Handles Anchor error objects, hex codes in logs, and unknown shapes.
  */
 export function parseAllocatorError(error: unknown): string {
+  // Wallet rejection — user cancelled in their wallet
+  if (isWalletRejection(error)) return 'Transaction cancelled.'
+
   const code = extractErrorCode(error)
   if (code !== null && ERROR_MAP[code]) return ERROR_MAP[code]!
   return 'Transaction failed. Please try again.'
+}
+
+function isWalletRejection(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const msg = String((error as Record<string, unknown>).message ?? '')
+  return (
+    msg.includes('User rejected') ||
+    msg.includes('user rejected') ||
+    msg.includes('Transaction cancelled') ||
+    msg.includes('WalletSignTransactionError')
+  )
 }
 
 function extractErrorCode(error: unknown): number | null {


### PR DESCRIPTION
## Summary

- Wire DepositForm → `buildDepositInstruction` with wallet adapter
- Wire WithdrawForm → `buildRequestWithdrawInstruction` + instant redemption on devnet
- Toast notification system (success/error/info, auto-dismiss)
- Wallet rejection detection (friendly "Transaction cancelled" message)
- Devnet banner ("You're on Devnet — test USDC, not real funds")
- Onboarding card (Solana faucet, test USDC mint, Phantom devnet instructions)

## Test plan

- [ ] Connect Phantom wallet (devnet mode)
- [ ] Navigate to `/app/vaults/moderate`
- [ ] Enter amount, click "Confirm Deposit" → wallet popup → confirm → success toast
- [ ] Reject transaction → "Transaction cancelled" toast
- [ ] Switch to Withdraw tab → confirm withdrawal → success toast
- [ ] Devnet banner visible at top of all `/app/*` pages
- [ ] Onboarding card visible below guardrails on vault detail