### PR TITLE
fix: P0-critical RPC key exposure + share price (#21, #22)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Solana RPC endpoint (server-side only — never use NEXT_PUBLIC_ for keys)
+HELIUS_RPC_URL=https://api.devnet.solana.com
+
+# Public config (safe to expose)
+NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID=2QtJ5kmxLuW2jYCFpJMtzZ7PCnKdoMwkeueYoDUi5z5P
+NEXT_PUBLIC_USDC_MINT=BiTXT15XyfSakk5Yz8L8QrzHPWbK8NjoZeEMFrDvKdKh
+NEXT_PUBLIC_KEEPER_API_URL=http://localhost:3001

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            NEXT_PUBLIC_RPC_URL=${{ secrets.NEXT_PUBLIC_RPC_URL }}
+            HELIUS_RPC_URL=${{ secrets.HELIUS_RPC_URL }}
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1.0.3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV HELIUS_RPC_URL=https://api.devnet.solana.com
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,9 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
-ARG NEXT_PUBLIC_RPC_URL=https://api.devnet.solana.com
 ARG NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID=2QtJ5kmxLuW2jYCFpJMtzZ7PCnKdoMwkeueYoDUi5z5P
 ARG NEXT_PUBLIC_USDC_MINT=BiTXT15XyfSakk5Yz8L8QrzHPWbK8NjoZeEMFrDvKdKh
 ARG NEXT_PUBLIC_KEEPER_API_URL=https://keeper.nanuqfi.com
-ENV NEXT_PUBLIC_RPC_URL=$NEXT_PUBLIC_RPC_URL
 ENV NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID=$NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID
 ENV NEXT_PUBLIC_USDC_MINT=$NEXT_PUBLIC_USDC_MINT
 ENV NEXT_PUBLIC_KEEPER_API_URL=$NEXT_PUBLIC_KEEPER_API_URL
@@ -25,6 +23,7 @@ FROM base AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV HELIUS_RPC_URL=https://api.devnet.solana.com
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "9001:3000"
     environment:
-      - NEXT_PUBLIC_RPC_URL=${NEXT_PUBLIC_RPC_URL:-https://api.devnet.solana.com}
+      - HELIUS_RPC_URL=${HELIUS_RPC_URL:-https://api.devnet.solana.com}
       - NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID=${NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID:-CDhkMBnc43wJQyVaSrreXk2ojvQvZMWrAWNBLSjaRJxq}
       - NEXT_PUBLIC_KEEPER_API_URL=${NEXT_PUBLIC_KEEPER_API_URL:-https://keeper.nanuqfi.xyz}
     healthcheck:

--- a/src/app/api/rpc/__tests__/route.test.ts
+++ b/src/app/api/rpc/__tests__/route.test.ts
@@ -7,6 +7,7 @@ vi.stubGlobal('fetch', mockFetch)
 describe('RPC proxy route', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.resetModules()
     vi.stubEnv('HELIUS_RPC_URL', 'https://devnet.helius-rpc.com/?api-key=test-key')
   })
 
@@ -18,10 +19,11 @@ describe('RPC proxy route', () => {
     })
 
     const { POST } = await import('../route')
+    const requestBody = JSON.stringify({ jsonrpc: '2.0', method: 'getAccountInfo', id: 1 })
     const request = new Request('http://localhost:3000/api/rpc', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ jsonrpc: '2.0', method: 'getHealth', id: 1 }),
+      body: requestBody,
     })
 
     const response = await POST(request as any)
@@ -31,15 +33,16 @@ describe('RPC proxy route', () => {
     expect(data).toEqual(rpcResponse)
     expect(mockFetch).toHaveBeenCalledWith(
       'https://devnet.helius-rpc.com/?api-key=test-key',
-      expect.objectContaining({ method: 'POST' }),
+      expect.objectContaining({
+        method: 'POST',
+        body: requestBody,
+      }),
     )
   })
 
   it('returns 503 when HELIUS_RPC_URL is not configured', async () => {
     vi.stubEnv('HELIUS_RPC_URL', '')
 
-    // Re-import to pick up new env
-    vi.resetModules()
     const { POST } = await import('../route')
     const request = new Request('http://localhost:3000/api/rpc', {
       method: 'POST',
@@ -48,5 +51,54 @@ describe('RPC proxy route', () => {
 
     const response = await POST(request as any)
     expect(response.status).toBe(503)
+  })
+
+  it('returns 400 for disallowed JSON-RPC method', async () => {
+    const { POST } = await import('../route')
+    const request = new Request('http://localhost:3000/api/rpc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'getHealth', id: 1 }),
+    })
+
+    const response = await POST(request as any)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error.code).toBe(-32601)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 for malformed JSON body', async () => {
+    const { POST } = await import('../route')
+    const request = new Request('http://localhost:3000/api/rpc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-valid-json{{{',
+    })
+
+    const response = await POST(request as any)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error.code).toBe(-32700)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('returns 502 when upstream fetch throws', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network failure'))
+
+    const { POST } = await import('../route')
+    const request = new Request('http://localhost:3000/api/rpc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'getBalance', id: 2 }),
+    })
+
+    const response = await POST(request as any)
+    const data = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(data.error.code).toBe(-32603)
   })
 })

--- a/src/app/api/rpc/__tests__/route.test.ts
+++ b/src/app/api/rpc/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+describe('RPC proxy route', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubEnv('HELIUS_RPC_URL', 'https://devnet.helius-rpc.com/?api-key=test-key')
+  })
+
+  it('forwards valid JSON-RPC POST to Helius and returns response', async () => {
+    const rpcResponse = { jsonrpc: '2.0', result: 'ok', id: 1 }
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(rpcResponse)),
+    })
+
+    const { POST } = await import('../route')
+    const request = new Request('http://localhost:3000/api/rpc', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'getHealth', id: 1 }),
+    })
+
+    const response = await POST(request as any)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(rpcResponse)
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://devnet.helius-rpc.com/?api-key=test-key',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('returns 503 when HELIUS_RPC_URL is not configured', async () => {
+    vi.stubEnv('HELIUS_RPC_URL', '')
+
+    // Re-import to pick up new env
+    vi.resetModules()
+    const { POST } = await import('../route')
+    const request = new Request('http://localhost:3000/api/rpc', {
+      method: 'POST',
+      body: '{}',
+    })
+
+    const response = await POST(request as any)
+    expect(response.status).toBe(503)
+  })
+})

--- a/src/app/api/rpc/route.ts
+++ b/src/app/api/rpc/route.ts
@@ -1,5 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+const ALLOWED_METHODS = new Set([
+  'getAccountInfo', 'getBalance', 'getLatestBlockhash', 'getSlot',
+  'getTokenAccountBalance', 'getTokenAccountsByOwner', 'getTransaction',
+  'getSignatureStatuses', 'getMinimumBalanceForRentExemption',
+  'sendTransaction', 'simulateTransaction', 'getRecentPrioritizationFees',
+  'getMultipleAccounts', 'getProgramAccounts', 'getBlockHeight',
+])
+
 export async function POST(request: NextRequest) {
   const rpcUrl = process.env.HELIUS_RPC_URL
 
@@ -10,17 +18,44 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const body = await request.text()
+  let body: string
+  try {
+    body = await request.text()
+    const parsed = JSON.parse(body)
 
-  const response = await fetch(rpcUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body,
-  })
+    // Support single and batch requests
+    const requests = Array.isArray(parsed) ? parsed : [parsed]
+    for (const req of requests) {
+      if (!req.method || !ALLOWED_METHODS.has(req.method)) {
+        return NextResponse.json(
+          { jsonrpc: '2.0', error: { code: -32601, message: 'Method not allowed' }, id: req.id ?? null },
+          { status: 400 },
+        )
+      }
+    }
+  } catch {
+    return NextResponse.json(
+      { jsonrpc: '2.0', error: { code: -32700, message: 'Parse error' }, id: null },
+      { status: 400 },
+    )
+  }
 
-  const data = await response.text()
-  return new NextResponse(data, {
-    status: response.status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  try {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+
+    const data = await response.text()
+    return new NextResponse(data, {
+      status: response.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch {
+    return NextResponse.json(
+      { jsonrpc: '2.0', error: { code: -32603, message: 'Upstream RPC error' }, id: null },
+      { status: 502 },
+    )
+  }
 }

--- a/src/app/api/rpc/route.ts
+++ b/src/app/api/rpc/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(request: NextRequest) {
+  const rpcUrl = process.env.HELIUS_RPC_URL
+
+  if (!rpcUrl) {
+    return NextResponse.json(
+      { jsonrpc: '2.0', error: { code: -32603, message: 'RPC endpoint not configured' }, id: null },
+      { status: 503 },
+    )
+  }
+
+  const body = await request.text()
+
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  })
+
+  const data = await response.text()
+  return new NextResponse(data, {
+    status: response.status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}

--- a/src/app/app/vaults/[riskLevel]/page.tsx
+++ b/src/app/app/vaults/[riskLevel]/page.tsx
@@ -265,6 +265,7 @@ function VaultDetailContent({
             walletBalance={walletBalance}
             shareMint={onChain.data?.shareMint}
             userShares={userPosition.data?.shares}
+            sharePrice={onChain.data?.sharePrice}
             redemptionPeriodSlots={onChain.data?.redemptionPeriodSlots}
             onSuccess={() => {
               onChain.refresh()

--- a/src/components/app/__tests__/deposit-form-share-price.test.tsx
+++ b/src/components/app/__tests__/deposit-form-share-price.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DepositForm } from '../deposit-form'
+
+// Mock wallet + connection
+vi.mock('@solana/wallet-adapter-react', () => ({
+  useWallet: () => ({ publicKey: null, sendTransaction: vi.fn() }),
+  useConnection: () => ({ connection: {} }),
+}))
+vi.mock('@/components/ui/toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}))
+
+describe('DepositForm share price handling', () => {
+  const baseProps = {
+    riskLevel: 'moderate' as const,
+    riskLevelNum: 1,
+    apy: 0.08,
+    dailyEarnings: 0.22,
+  }
+
+  it('MAX button uses share price for withdraw USDC estimate', () => {
+    render(
+      <DepositForm
+        {...baseProps}
+        userShares={100_000_000n}
+        sharePrice={1.2}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('Withdraw'))
+    fireEvent.click(screen.getByText('MAX'))
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement
+    expect(Number(input.value)).toBeCloseTo(120, 1)
+  })
+
+  it('MAX button defaults to 1:1 when sharePrice not provided', () => {
+    render(
+      <DepositForm
+        {...baseProps}
+        userShares={100_000_000n}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('Withdraw'))
+    fireEvent.click(screen.getByText('MAX'))
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement
+    expect(Number(input.value)).toBeCloseTo(100, 1)
+  })
+})

--- a/src/components/app/deposit-form.tsx
+++ b/src/components/app/deposit-form.tsx
@@ -157,7 +157,7 @@ export function DepositForm({
     } finally {
       setLoading(false)
     }
-  }, [publicKey, parsedAmount, riskLevelNum, shareMint, redemptionPeriodSlots, sendTransaction, connection, toast, onSuccess])
+  }, [publicKey, parsedAmount, riskLevelNum, shareMint, sharePrice, redemptionPeriodSlots, sendTransaction, connection, toast, onSuccess])
 
   function handleSubmit() {
     if (mode === 'deposit') {

--- a/src/components/app/deposit-form.tsx
+++ b/src/components/app/deposit-form.tsx
@@ -26,6 +26,7 @@ interface DepositFormProps {
   walletBalance?: number
   shareMint?: PublicKey
   userShares?: bigint
+  sharePrice?: number
   redemptionPeriodSlots?: bigint
   onSuccess?: () => void
 }
@@ -44,6 +45,7 @@ export function DepositForm({
   walletBalance,
   shareMint,
   userShares,
+  sharePrice,
   redemptionPeriodSlots,
   onSuccess,
 }: DepositFormProps) {
@@ -71,9 +73,9 @@ export function DepositForm({
     if (mode === 'deposit' && walletBalance !== undefined && walletBalance > 0) {
       setAmount(String(walletBalance))
     } else if (mode === 'withdraw' && userShares !== undefined && userShares > 0n) {
-      // Convert shares back to approximate USDC for display
-      // Share price ~1:1 at initialization, so shares / 1e6 gives USDC
-      setAmount(String(Number(userShares) / 10 ** USDC_DECIMALS))
+      // Convert shares to USDC using actual share price
+      const price = sharePrice ?? 1
+      setAmount(String(Number(userShares) * price / 10 ** USDC_DECIMALS))
     }
   }
 
@@ -113,9 +115,9 @@ export function DepositForm({
 
     setLoading(true)
     try {
-      // Convert entered USDC amount to shares
-      // For simplicity, treat 1 share = 1 USDC smallest unit at 1:1 price
-      const sharesAmount = BigInt(Math.round(parsedAmount * 10 ** USDC_DECIMALS))
+      // Convert entered USDC amount to shares using actual share price
+      const price = sharePrice ?? 1
+      const sharesAmount = BigInt(Math.round(parsedAmount / price * 10 ** USDC_DECIMALS))
 
       const requestIx = await buildRequestWithdrawInstruction(
         publicKey,
@@ -213,7 +215,7 @@ export function DepositForm({
           )}
           {mode === 'withdraw' && userShares !== undefined && (
             <span className="text-xs text-slate-500 font-mono">
-              Shares: {(Number(userShares) / 10 ** USDC_DECIMALS).toLocaleString('en-US', { maximumFractionDigits: 2 })}
+              Value: {(Number(userShares) * (sharePrice ?? 1) / 10 ** USDC_DECIMALS).toLocaleString('en-US', { maximumFractionDigits: 2 })} USDC
             </span>
           )}
         </div>

--- a/src/providers/solana-provider.tsx
+++ b/src/providers/solana-provider.tsx
@@ -7,7 +7,9 @@ import { PhantomWalletAdapter, SolflareWalletAdapter } from '@solana/wallet-adap
 
 import '@solana/wallet-adapter-react-ui/styles.css'
 
-const RPC_URL = '/api/rpc'
+const RPC_URL = typeof window !== 'undefined'
+  ? `${window.location.origin}/api/rpc`
+  : (process.env.HELIUS_RPC_URL ?? 'https://api.devnet.solana.com')
 
 export function SolanaProvider({ children }: { children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false)

--- a/src/providers/solana-provider.tsx
+++ b/src/providers/solana-provider.tsx
@@ -7,7 +7,7 @@ import { PhantomWalletAdapter, SolflareWalletAdapter } from '@solana/wallet-adap
 
 import '@solana/wallet-adapter-react-ui/styles.css'
 
-const RPC_URL = process.env.NEXT_PUBLIC_RPC_URL ?? 'https://api.devnet.solana.com'
+const RPC_URL = '/api/rpc'
 
 export function SolanaProvider({ children }: { children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false)


### PR DESCRIPTION
## Summary
- Move Helius RPC key from `NEXT_PUBLIC_` to server-side `/api/rpc` proxy (#21)
- Use actual on-chain share price in withdraw calculations (#22)
- Harden RPC proxy with method allowlist and error handling

## Changes
- `src/app/api/rpc/route.ts`: Server-side JSON-RPC proxy with method allowlist
- `src/providers/solana-provider.tsx`: Absolute URL via `window.location.origin`
- `src/components/app/deposit-form.tsx`: `sharePrice` prop, correct conversion math
- `src/app/app/vaults/[riskLevel]/page.tsx`: Passes `sharePrice` to DepositForm
- `.env.local`: `NEXT_PUBLIC_RPC_URL` → `HELIUS_RPC_URL`
- `.env.example`: Safe defaults (no real keys)
- `Dockerfile` + `docker-compose.yml`: Updated env var name
- `.github/workflows/deploy.yml`: Updated secret reference

## Test plan
- [x] `grep NEXT_PUBLIC_RPC_URL src/` — zero hits
- [x] RPC proxy tests: valid POST → 200, missing env → 503, disallowed method → 400, malformed JSON → 400, upstream error → 502
- [x] Share price tests: 1.2x price + 100 shares = 120 USDC, default 1:1 = 100 USDC
- [x] `pnpm vitest run` — 69 tests pass
- [x] `pnpm build` — succeeds
- [ ] Add `HELIUS_RPC_URL` secret in GitHub repo settings