### PR TITLE
fix: P2 cleanup — 10 issues (#17-#20,#30-#35)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@solana/wallet-adapter-wallets": "^0.19.37",
     "@solana/web3.js": "^1.98.4",
     "lucide-react": "^0.577.0",
-    "next": "16.1.6",
+    "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
@@ -30,7 +30,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.1.6",
+    "eslint-config-next": "16.1.7",
     "jsdom": "^29.0.1",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.3)
       next:
-        specifier: 16.1.6
-        version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 16.1.7
+        version: 16.1.7(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -61,8 +61,8 @@ importers:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
-        specifier: 16.1.6
-        version: 16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 16.1.7
+        version: 16.1.7(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1(@noble/hashes@2.0.1)
@@ -652,56 +652,56 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@next/env@16.1.6':
-    resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
+  '@next/env@16.1.7':
+    resolution: {integrity: sha512-rJJbIdJB/RQr2F1nylZr/PJzamvNNhfr3brdKP6s/GW850jbtR70QlSfFselvIBbcPUOlQwBakexjFzqLzF6pg==}
 
-  '@next/eslint-plugin-next@16.1.6':
-    resolution: {integrity: sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==}
+  '@next/eslint-plugin-next@16.1.7':
+    resolution: {integrity: sha512-v/bRGOJlfRCO+NDKt0bZlIIWjhMKU8xbgEQBo+rV9C8S6czZvs96LZ/v24/GvpEnovZlL4QDpku/RzWHVbmPpA==}
 
-  '@next/swc-darwin-arm64@16.1.6':
-    resolution: {integrity: sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==}
+  '@next/swc-darwin-arm64@16.1.7':
+    resolution: {integrity: sha512-b2wWIE8sABdyafc4IM8r5Y/dS6kD80JRtOGrUiKTsACFQfWWgUQ2NwoUX1yjFMXVsAwcQeNpnucF2ZrujsBBPg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.1.6':
-    resolution: {integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==}
+  '@next/swc-darwin-x64@16.1.7':
+    resolution: {integrity: sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
-    resolution: {integrity: sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==}
+  '@next/swc-linux-arm64-gnu@16.1.7':
+    resolution: {integrity: sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.1.6':
-    resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
+  '@next/swc-linux-arm64-musl@16.1.7':
+    resolution: {integrity: sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.1.6':
-    resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
+  '@next/swc-linux-x64-gnu@16.1.7':
+    resolution: {integrity: sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.1.6':
-    resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
+  '@next/swc-linux-x64-musl@16.1.7':
+    resolution: {integrity: sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
-    resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
+  '@next/swc-win32-arm64-msvc@16.1.7':
+    resolution: {integrity: sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.1.6':
-    resolution: {integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==}
+  '@next/swc-win32-x64-msvc@16.1.7':
+    resolution: {integrity: sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3184,8 +3184,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@16.1.6:
-    resolution: {integrity: sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==}
+  eslint-config-next@16.1.7:
+    resolution: {integrity: sha512-FTq1i/QDltzq+zf9aB/cKWAiZ77baG0V7h8dRQh3thVx7I4dwr6ZXQrWKAaTB7x5VwVXlzoUTyMLIVQPLj2gJg==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -4387,8 +4387,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  next@16.1.6:
-    resolution: {integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==}
+  next@16.1.7:
+    resolution: {integrity: sha512-WM0L7WrSvKwoLegLYr6V+mz+RIofqQgVAfHhMp9a88ms0cFX8iX9ew+snpWlSBwpkURJOUdvCEt3uLl3NNzvWg==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -6461,34 +6461,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.1.6': {}
+  '@next/env@16.1.7': {}
 
-  '@next/eslint-plugin-next@16.1.6':
+  '@next/eslint-plugin-next@16.1.7':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.1.6':
+  '@next/swc-darwin-arm64@16.1.7':
     optional: true
 
-  '@next/swc-darwin-x64@16.1.6':
+  '@next/swc-darwin-x64@16.1.7':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.1.6':
+  '@next/swc-linux-arm64-gnu@16.1.7':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.1.6':
+  '@next/swc-linux-arm64-musl@16.1.7':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.1.6':
+  '@next/swc-linux-x64-gnu@16.1.7':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.1.6':
+  '@next/swc-linux-x64-musl@16.1.7':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.1.6':
+  '@next/swc-win32-arm64-msvc@16.1.7':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.1.6':
+  '@next/swc-win32-x64-msvc@16.1.7':
     optional: true
 
   '@ngraveio/bc-ur@1.1.13':
@@ -10389,9 +10389,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.6(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-config-next@16.1.7(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.1.6
+      '@next/eslint-plugin-next': 16.1.7
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
@@ -11775,9 +11775,9 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.7(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 16.1.6
+      '@next/env': 16.1.7
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.8
       caniuse-lite: 1.0.30001779
@@ -11786,14 +11786,14 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.6
-      '@next/swc-darwin-x64': 16.1.6
-      '@next/swc-linux-arm64-gnu': 16.1.6
-      '@next/swc-linux-arm64-musl': 16.1.6
-      '@next/swc-linux-x64-gnu': 16.1.6
-      '@next/swc-linux-x64-musl': 16.1.6
-      '@next/swc-win32-arm64-msvc': 16.1.6
-      '@next/swc-win32-x64-msvc': 16.1.6
+      '@next/swc-darwin-arm64': 16.1.7
+      '@next/swc-darwin-x64': 16.1.7
+      '@next/swc-linux-arm64-gnu': 16.1.7
+      '@next/swc-linux-arm64-musl': 16.1.7
+      '@next/swc-linux-x64-gnu': 16.1.7
+      '@next/swc-linux-x64-musl': 16.1.7
+      '@next/swc-win32-arm64-msvc': 16.1.7
+      '@next/swc-win32-x64-msvc': 16.1.7
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'

--- a/src/app/app/error.tsx
+++ b/src/app/app/error.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { useEffect } from 'react'
 import Link from 'next/link'
+import { reportError } from '@/lib/error-reporting'
 
 export default function AppError({
   error,
@@ -9,6 +11,10 @@ export default function AppError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  useEffect(() => {
+    reportError(error, { domain: 'render', extra: { digest: error.digest, boundary: 'app' } })
+  }, [error])
+
   return (
     <div className="min-h-[60vh] flex items-center justify-center p-6">
       <div className="max-w-md text-center space-y-4">

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -20,22 +20,31 @@ import {
 
 const ACTIVE_RISK_LEVELS: RiskLevel[] = ['moderate', 'aggressive']
 
-function useVaultWithFallback(riskLevel: RiskLevel): Vault {
+interface VaultWithMeta {
+  vault: Vault
+  isMockData: boolean
+}
+
+function useVaultWithFallback(riskLevel: RiskLevel): VaultWithMeta {
   const live = useVaultData(riskLevel)
   const mock = mockVaults.find(v => v.riskLevel === riskLevel)
+  const isMockData = !live.loading && !live.data
 
   return {
-    riskLevel,
-    tvl: live.data?.tvl ?? mock?.tvl ?? 0,
-    apy: normalizeApy(live.data?.apy ?? mock?.apy ?? 0),
-    drawdown: live.data?.drawdown ?? mock?.drawdown ?? 0,
-    weights: live.data?.weights ?? mock?.weights ?? {},
-    guardrails: mock?.guardrails ?? {
-      maxDrawdown: 5,
-      currentDrawdown: 0,
-      maxPerp: 0,
-      currentPerp: 0,
+    vault: {
+      riskLevel,
+      tvl: live.data?.tvl ?? mock?.tvl ?? 0,
+      apy: normalizeApy(live.data?.apy ?? mock?.apy ?? 0),
+      drawdown: live.data?.drawdown ?? mock?.drawdown ?? 0,
+      weights: live.data?.weights ?? mock?.weights ?? {},
+      guardrails: mock?.guardrails ?? {
+        maxDrawdown: 5,
+        currentDrawdown: 0,
+        maxPerp: 0,
+        currentPerp: 0,
+      },
     },
+    isMockData,
   }
 }
 
@@ -64,12 +73,17 @@ export default function DashboardPage() {
     ? Number(usdcBalance.data) / 1e6
     : undefined
 
-  const moderateVault = useVaultWithFallback('moderate')
-  const aggressiveVault = useVaultWithFallback('aggressive')
+  const { vault: moderateVault, isMockData: modIsMock } = useVaultWithFallback('moderate')
+  const { vault: aggressiveVault, isMockData: aggIsMock } = useVaultWithFallback('aggressive')
 
   const vaults: Record<string, Vault> = {
     moderate: moderateVault,
     aggressive: aggressiveVault,
+  }
+
+  const mockFlags: Record<string, boolean> = {
+    moderate: modIsMock,
+    aggressive: aggIsMock,
   }
 
   const decisionsHook = useAllDecisions()
@@ -107,9 +121,10 @@ export default function DashboardPage() {
           {ACTIVE_RISK_LEVELS.map(level => (
             <VaultCard
               key={level}
-              vault={vaults[level]}
+              vault={vaults[level]!}
               deposited={isConnected ? (level === 'moderate' ? userModValue : userAggValue) : undefined}
               isConnected={isConnected}
+              isMockData={mockFlags[level]}
             />
           ))}
         </div>

--- a/src/app/app/vaults/[riskLevel]/page.tsx
+++ b/src/app/app/vaults/[riskLevel]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, ArrowRight, ExternalLink } from 'lucide-react'
 import { GlassCard } from '@/components/ui/glass-card'
-import { Badge } from '@/components/ui/badge'
+import { Badge, MockDataBadge } from '@/components/ui/badge'
 import { YieldChart } from '@/components/app/yield-chart'
 import { ProtocolBar } from '@/components/app/protocol-bar'
 import { GuardrailCard } from '@/components/app/guardrail-card'
@@ -126,6 +126,9 @@ function VaultDetailContent({
   const maxSingleAsset = maxSingleAssetBps / 100
   const redemptionSlots = onChain.data?.redemptionPeriodSlots ?? 0n
 
+  // Detect mock-tier fallback: neither on-chain nor keeper data is available
+  const isMockData = !onChain.loading && !keeper.loading && !onChain.data && !keeper.data
+
   // Decisions: keeper API > mock fallback
   const decisions: KeeperDecision[] = useMemo(() => {
     if (keeperDecisions.data && keeperDecisions.data.length > 0) {
@@ -166,6 +169,7 @@ function VaultDetailContent({
           <h1 className="text-4xl font-bold text-white tracking-tight">
             USDC Optimal Yield
           </h1>
+          {isMockData && <MockDataBadge />}
         </div>
 
         {/* Right: stats pill */}

--- a/src/app/app/vaults/[riskLevel]/page.tsx
+++ b/src/app/app/vaults/[riskLevel]/page.tsx
@@ -59,7 +59,7 @@ export default function VaultDetailPage() {
             : 'Invalid risk level.'}
         </p>
         <Link
-          href="/vaults"
+          href="/app/vaults"
           className="inline-flex items-center gap-1.5 text-sm text-sky-400 hover:text-sky-300 transition-colors"
         >
           <ArrowLeft className="h-4 w-4" />
@@ -151,7 +151,7 @@ function VaultDetailContent({
     <div className="space-y-8">
       {/* Back link */}
       <Link
-        href="/vaults"
+        href="/app/vaults"
         className="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-slate-200 transition-colors"
       >
         <ArrowLeft className="h-4 w-4" />
@@ -232,7 +232,7 @@ function VaultDetailContent({
             <div className="flex items-center justify-between mb-5">
               <h3 className="text-lg font-semibold text-white">Recent Decisions</h3>
               <Link
-                href="/activity"
+                href="/app/activity"
                 className="flex items-center gap-1 text-xs text-slate-500 hover:text-sky-400 transition-colors"
               >
                 View all

--- a/src/app/app/vaults/page.tsx
+++ b/src/app/app/vaults/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { GlassCard } from '@/components/ui/glass-card'
-import { Badge } from '@/components/ui/badge'
+import { Badge, MockDataBadge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { ProtocolBar } from '@/components/app/protocol-bar'
 import { GuardrailCard } from '@/components/app/guardrail-card'
@@ -84,14 +84,18 @@ function VaultColumn({ vault }: { vault: Vault }) {
   const dailyEarnings = tvl * apy / 365
   const drawdown = vault.guardrails.maxDrawdown
 
+  // Mock-tier fallback: neither live source returned data
+  const isMockData = !onChain.loading && !keeper.loading && !onChain.data && !keeper.data
+
   return (
     <GlassCard
       tier={vault.riskLevel}
       className="relative flex flex-col p-0 overflow-hidden"
     >
       {/* Tier badge header */}
-      <div className={`bg-gradient-to-b ${config.gradient} px-6 pt-5 pb-4`}>
+      <div className={`bg-gradient-to-b ${config.gradient} px-6 pt-5 pb-4 flex items-center justify-between`}>
         <Badge tier={vault.riskLevel} />
+        {isMockData && <MockDataBadge />}
       </div>
 
       {/* Stats rows */}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import { useEffect } from 'react'
+import { reportError } from '@/lib/error-reporting'
+
 export default function GlobalError({
   error,
   reset,
@@ -7,6 +10,10 @@ export default function GlobalError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  useEffect(() => {
+    reportError(error, { domain: 'render', extra: { digest: error.digest, boundary: 'root' } })
+  }, [error])
+
   return (
     <div className="min-h-screen bg-[#080B11] flex items-center justify-center p-6">
       <div className="max-w-md text-center space-y-4">

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,5 +1,8 @@
 'use client'
 
+import { useEffect } from 'react'
+import { reportError } from '@/lib/error-reporting'
+
 export default function GlobalError({
   error,
   reset,
@@ -7,6 +10,10 @@ export default function GlobalError({
   error: Error & { digest?: string }
   reset: () => void
 }) {
+  useEffect(() => {
+    reportError(error, { domain: 'render', extra: { digest: error.digest, boundary: 'global' } })
+  }, [error])
+
   return (
     <html lang="en">
       <body className="bg-[#080B11] text-white">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,8 +13,20 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "NanuqFi — Yield, Routed.",
-  description: "AI-powered USDC yield routing across Kamino, Marginfi, and Lulo. Transparent allocations, real-time guardrails, and autonomous rebalancing.",
+  title: 'NanuqFi — AI-Powered Yield Routing',
+  description: 'Protocol-agnostic yield routing layer for DeFi. Deposit USDC, pick a risk level, earn optimized yield.',
+  openGraph: {
+    title: 'NanuqFi — AI-Powered Yield Routing',
+    description: 'Protocol-agnostic yield routing layer for DeFi.',
+    url: 'https://nanuqfi.com',
+    siteName: 'NanuqFi',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'NanuqFi — AI-Powered Yield Routing',
+    description: 'Protocol-agnostic yield routing layer for DeFi.',
+  },
 };
 
 export default function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/', disallow: '/api/' },
+    sitemap: 'https://nanuqfi.com/sitemap.xml',
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,9 @@
+import type { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    { url: 'https://nanuqfi.com', lastModified: new Date() },
+    { url: 'https://nanuqfi.com/strategy', lastModified: new Date() },
+    { url: 'https://nanuqfi.com/app', lastModified: new Date() },
+  ]
+}

--- a/src/app/strategy/page.tsx
+++ b/src/app/strategy/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { FadeIn } from '@/components/ui/fade-in'
 import { GlassCard } from '@/components/ui/glass-card'
 import {

--- a/src/components/app/decision-detail.tsx
+++ b/src/components/app/decision-detail.tsx
@@ -7,6 +7,7 @@ import {
   sourceDisplayName,
   type KeeperDecision,
 } from '@/lib/mock-data'
+import { solscanTxUrl } from '@/lib/network-config'
 
 interface DecisionDetailProps {
   decision: KeeperDecision | null
@@ -158,7 +159,7 @@ export function DecisionDetail({ decision }: DecisionDetailProps) {
           </span>
           {txSignature && truncatedTx ? (
             <a
-              href={`https://solscan.io/tx/${txSignature}?cluster=devnet`}
+              href={solscanTxUrl(txSignature)}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 text-sm text-sky-400 hover:text-sky-300 transition-colors font-mono"

--- a/src/components/app/decision-detail.tsx
+++ b/src/components/app/decision-detail.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ExternalLink, Bot, Cpu } from 'lucide-react'
 import { GlassCard } from '@/components/ui/glass-card'
 import { Badge } from '@/components/ui/badge'

--- a/src/components/app/deposit-form.tsx
+++ b/src/components/app/deposit-form.tsx
@@ -38,7 +38,8 @@ const USDC_DECIMALS = 6
 // ─── Component ──────────────────────────────────────────────────────────────
 
 export function DepositForm({
-  riskLevel,
+  // riskLevel is reserved for future use (e.g. analytics, display labels)
+  riskLevel: _riskLevel, // eslint-disable-line @typescript-eslint/no-unused-vars
   riskLevelNum,
   apy,
   dailyEarnings,

--- a/src/components/app/guardrail-card.tsx
+++ b/src/components/app/guardrail-card.tsx
@@ -1,5 +1,6 @@
 import { ShieldCheck, ExternalLink } from 'lucide-react'
 import { GlassCard } from '@/components/ui/glass-card'
+import { solscanAccountUrl, DEVNET_PROGRAM_ID } from '@/lib/network-config'
 
 interface Guardrail {
   label: string
@@ -15,8 +16,9 @@ interface GuardrailCardProps {
 
 // Display-only fallback — this is a Solscan link, not a transaction target.
 // Money-handling code in transactions.ts throws on missing env var.
+// MAINNET: update DEVNET_PROGRAM_ID in network-config.ts after redeployment.
 const DEFAULT_PROGRAM_ID =
-  process.env.NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID ?? '2QtJ5kmxLuW2jYCFpJMtzZ7PCnKdoMwkeueYoDUi5z5P'
+  process.env.NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID ?? DEVNET_PROGRAM_ID
 
 function truncateId(id: string): string {
   if (id.length <= 10) return id
@@ -28,7 +30,7 @@ export function GuardrailCard({
   programId = DEFAULT_PROGRAM_ID,
   className,
 }: GuardrailCardProps) {
-  const solscanUrl = `https://solscan.io/account/${programId}?cluster=devnet`
+  const solscanUrl = solscanAccountUrl(programId)
 
   return (
     <GlassCard className={['p-6 bg-[#111622]/40', className].filter(Boolean).join(' ')}>

--- a/src/components/app/guardrail-card.tsx
+++ b/src/components/app/guardrail-card.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { ShieldCheck, ExternalLink } from 'lucide-react'
 import { GlassCard } from '@/components/ui/glass-card'
 

--- a/src/components/app/nav.tsx
+++ b/src/components/app/nav.tsx
@@ -4,7 +4,8 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useWallet } from '@solana/wallet-adapter-react'
 import { useWalletModal } from '@solana/wallet-adapter-react-ui'
-import { BookOpen } from 'lucide-react'
+import { BookOpen, Menu, X } from 'lucide-react'
+import { useState } from 'react'
 
 import { SystemStatus } from '@/components/app/system-status'
 
@@ -27,10 +28,14 @@ export function Nav() {
   const pathname = usePathname()
   const { publicKey, disconnect, connected } = useWallet()
   const { setVisible } = useWalletModal()
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   return (
-    <nav className="fixed inset-x-0 top-8 z-50 h-16 bg-slate-900/80 backdrop-blur-xl border-b border-white/5">
-      <div className="mx-auto flex h-full max-w-[1440px] items-center justify-between px-4 sm:px-6 lg:px-8">
+    <nav
+      className="fixed inset-x-0 top-8 z-50 bg-slate-900/80 backdrop-blur-xl border-b border-white/5"
+      aria-label="Main navigation"
+    >
+      <div className="mx-auto flex h-16 max-w-[1440px] items-center justify-between px-4 sm:px-6 lg:px-8">
         {/* Left — Logo */}
         <Link href="/app" className="flex items-center gap-2.5">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-white/10 to-transparent border border-white/10 shadow-[0_0_15px_rgba(14,165,233,0.3)]">
@@ -42,7 +47,7 @@ export function Nav() {
           </span>
         </Link>
 
-        {/* Center — Pill Nav */}
+        {/* Center — Pill Nav (desktop) */}
         <div className="hidden sm:flex items-center bg-slate-900/50 p-1 rounded-full border border-white/5">
           {NAV_ITEMS.map(({ label, href }) => {
             const active = isActive(pathname, href)
@@ -50,6 +55,7 @@ export function Nav() {
               <Link
                 key={href}
                 href={href}
+                aria-current={active ? 'page' : undefined}
                 className={`px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
                   active
                     ? 'bg-slate-800 text-white shadow-sm ring-1 ring-white/10'
@@ -62,7 +68,7 @@ export function Nav() {
           })}
         </div>
 
-        {/* Right — Strategy + Status + Wallet */}
+        {/* Right — Strategy + Status + Wallet + Mobile Toggle */}
         <div className="flex items-center gap-3">
           <Link
             href="/strategy"
@@ -76,22 +82,75 @@ export function Nav() {
 
           {connected && publicKey ? (
             <button
+              type="button"
               onClick={() => disconnect()}
+              aria-label={`Disconnect wallet ${truncateAddress(publicKey.toBase58())}`}
               className="flex items-center gap-2 rounded-lg bg-slate-800 px-3 py-2 text-sm font-medium text-slate-200 border border-white/5 hover:bg-slate-700 transition-colors"
             >
-              <span className="h-2 w-2 rounded-full bg-emerald-400" />
+              <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden="true" />
               {truncateAddress(publicKey.toBase58())}
             </button>
           ) : (
             <button
+              type="button"
               onClick={() => setVisible(true)}
               className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-medium text-white hover:bg-sky-500 transition-colors"
             >
               Connect Wallet
             </button>
           )}
+
+          {/* Mobile hamburger — visible below sm breakpoint */}
+          <button
+            type="button"
+            aria-label={mobileOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-expanded={mobileOpen}
+            aria-controls="mobile-nav-menu"
+            onClick={() => setMobileOpen(prev => !prev)}
+            className="sm:hidden flex items-center justify-center h-9 w-9 rounded-lg border border-white/5 bg-slate-800/60 text-slate-400 hover:text-slate-200 transition-colors"
+          >
+            {mobileOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+          </button>
         </div>
       </div>
+
+      {/* Mobile dropdown menu */}
+      {mobileOpen && (
+        <div
+          id="mobile-nav-menu"
+          role="menu"
+          className="sm:hidden border-t border-white/5 bg-slate-900/95 backdrop-blur-xl px-4 py-3 space-y-1"
+        >
+          {NAV_ITEMS.map(({ label, href }) => {
+            const active = isActive(pathname, href)
+            return (
+              <Link
+                key={href}
+                href={href}
+                role="menuitem"
+                aria-current={active ? 'page' : undefined}
+                onClick={() => setMobileOpen(false)}
+                className={`block px-4 py-2.5 rounded-xl text-sm font-medium transition-colors ${
+                  active
+                    ? 'bg-slate-800 text-white'
+                    : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800/50'
+                }`}
+              >
+                {label}
+              </Link>
+            )
+          })}
+          <Link
+            href="/strategy"
+            role="menuitem"
+            onClick={() => setMobileOpen(false)}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-xl text-sm font-medium text-slate-400 hover:text-slate-200 hover:bg-slate-800/50 transition-colors"
+          >
+            <BookOpen className="w-4 h-4" />
+            Strategy Docs
+          </Link>
+        </div>
+      )}
     </nav>
   )
 }

--- a/src/components/app/protocol-bar.tsx
+++ b/src/components/app/protocol-bar.tsx
@@ -47,12 +47,15 @@ export function ProtocolBar({ name, percentage, apy, color, reasoning }: Protoco
           {reasoning && (
             <button
               type="button"
+              aria-label={`${expanded ? 'Hide' : 'Show'} allocation reasoning for ${name}`}
+              aria-expanded={expanded}
               onClick={() => setExpanded(!expanded)}
               className="flex items-center gap-0.5 text-[11px] text-slate-500 hover:text-slate-300 transition-colors"
             >
-              why {percentage}%?
+              why {percentage.toFixed(1)}%?
               <ChevronDown
                 className={`h-3 w-3 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+                aria-hidden="true"
               />
             </button>
           )}

--- a/src/components/app/vault-card.tsx
+++ b/src/components/app/vault-card.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { useWalletModal } from '@solana/wallet-adapter-react-ui'
 import { GlassCard } from '@/components/ui/glass-card'
-import { Badge } from '@/components/ui/badge'
+import { Badge, MockDataBadge } from '@/components/ui/badge'
 import { ConfidenceBar } from '@/components/ui/confidence-bar'
 import { formatUsd, formatApy, formatDailyEarnings, normalizeApy, type Vault } from '@/lib/mock-data'
 
@@ -24,9 +24,10 @@ interface VaultCardProps {
   deposited?: number
   confidence?: number
   isConnected?: boolean
+  isMockData?: boolean
 }
 
-export function VaultCard({ vault, deposited, confidence, isConnected }: VaultCardProps) {
+export function VaultCard({ vault, deposited, confidence, isConnected, isMockData }: VaultCardProps) {
   const { setVisible } = useWalletModal()
   const hasPosition = deposited !== undefined && deposited > 0
   const apy = normalizeApy(vault.apy)
@@ -50,7 +51,10 @@ export function VaultCard({ vault, deposited, confidence, isConnected }: VaultCa
       >
         {/* Top — Badge + APY */}
         <div className="flex items-center justify-between">
-          <Badge tier={vault.riskLevel} />
+          <div className="flex items-center gap-2">
+            <Badge tier={vault.riskLevel} />
+            {isMockData && <MockDataBadge />}
+          </div>
           <span className="text-3xl font-mono tabular-nums text-white">
             {formatApy(apy)}
           </span>

--- a/src/components/app/yield-chart.tsx
+++ b/src/components/app/yield-chart.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { GlassCard } from '@/components/ui/glass-card'
 import { TimeRangeSelector } from '@/components/ui/time-range-selector'
 

--- a/src/components/marketing/ai-transparency.tsx
+++ b/src/components/marketing/ai-transparency.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Bot } from 'lucide-react'
 import { FadeIn } from '@/components/ui/fade-in'
 import { GlassCard } from '@/components/ui/glass-card'

--- a/src/components/marketing/how-it-works.tsx
+++ b/src/components/marketing/how-it-works.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Wallet, Shield, Zap } from 'lucide-react'
 import { FadeIn } from '@/components/ui/fade-in'
 import { GlassCard } from '@/components/ui/glass-card'

--- a/src/components/marketing/performance-proof.tsx
+++ b/src/components/marketing/performance-proof.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { FadeIn } from '@/components/ui/fade-in'
 import { GlassCard } from '@/components/ui/glass-card'
 import backtestData from '@/data/backtest-results.json'

--- a/src/components/marketing/tier-showcase.tsx
+++ b/src/components/marketing/tier-showcase.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { FadeIn } from '@/components/ui/fade-in'
 import { GlassCard } from '@/components/ui/glass-card'
 import { Badge } from '@/components/ui/badge'

--- a/src/components/marketing/trust-bar.tsx
+++ b/src/components/marketing/trust-bar.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { FadeIn } from '@/components/ui/fade-in'
 
 const items = [

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import { ShieldCheck, Scale, Zap } from 'lucide-react'
+import { ShieldCheck, Scale, Zap, FlaskConical } from 'lucide-react'
 import type { RiskLevel } from '@/lib/mock-data'
 
 // ─── Static class maps ────────────────────────────────────────────────────────
@@ -25,6 +25,32 @@ interface BadgeProps {
   tier: RiskLevel
   className?: string
 }
+
+// ─── MockDataBadge ────────────────────────────────────────────────────────────
+// Shown when live on-chain and keeper data are unavailable — alerts users
+// they're seeing demo/fallback values, not real-time protocol data.
+
+interface MockDataBadgeProps {
+  className?: string
+}
+
+export function MockDataBadge({ className }: MockDataBadgeProps) {
+  return (
+    <span
+      className={[
+        'inline-flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium',
+        'bg-slate-700/50 text-slate-500 border border-slate-700 rounded-full',
+        className,
+      ].filter(Boolean).join(' ')}
+      title="Live on-chain and keeper data unavailable — showing demo values"
+    >
+      <FlaskConical className="w-2.5 h-2.5" />
+      Demo data
+    </span>
+  )
+}
+
+// ─── Badge ────────────────────────────────────────────────────────────────────
 
 export function Badge({ tier, className }: BadgeProps) {
   const { label, icon: Icon } = tierConfig[tier]

--- a/src/hooks/use-allocator.ts
+++ b/src/hooks/use-allocator.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useConnection, useWallet } from '@solana/wallet-adapter-react'
-import { PublicKey } from '@solana/web3.js'
+import { Connection, PublicKey } from '@solana/web3.js'
 import { getAssociatedTokenAddress } from '@solana/spl-token'
 import { useState, useEffect, useCallback, useRef } from 'react'
 import {
@@ -9,6 +9,31 @@ import {
   getRiskVaultPDA,
   getUserPositionPDA,
 } from '@/lib/transactions'
+
+// ─── In-Flight Request Deduplication ─────────────────────────────────────────
+// When multiple hooks call getAccountInfo on the same address simultaneously
+// (e.g. on mount or visibility change), we deduplicate by caching the in-flight
+// Promise. All callers awaiting the same address share one RPC call.
+// The cache entry is deleted once the promise settles to allow future polls.
+
+type AccountInfoResult = Awaited<ReturnType<Connection['getAccountInfo']>>
+
+const _inFlightGetAccountInfo = new Map<string, Promise<AccountInfoResult>>()
+
+function deduplicatedGetAccountInfo(
+  connection: Connection,
+  pubkey: PublicKey
+): Promise<AccountInfoResult> {
+  const key = pubkey.toBase58()
+  const existing = _inFlightGetAccountInfo.get(key)
+  if (existing) return existing
+
+  const promise = connection.getAccountInfo(pubkey).finally(() => {
+    _inFlightGetAccountInfo.delete(key)
+  })
+  _inFlightGetAccountInfo.set(key, promise)
+  return promise
+}
 
 // ─── Account Parsing ─────────────────────────────────────────────────────────
 // Manual Borsh deserialization matching `programs/allocator/src/state.rs`.
@@ -191,7 +216,12 @@ interface HookResult<T> {
   refresh: () => void
 }
 
-const POLL_INTERVAL = 15_000
+// Increased from 15s to 30s — reduces RPC call frequency by 50% while
+// keeping data fresh enough for a yield dashboard context.
+// All hooks share the same interval, so thundering herd risk is at mount
+// time only (each hook does one immediate fetch). Stagger is handled by
+// the fact that hooks mount sequentially and use independent intervals.
+const POLL_INTERVAL = 30_000
 
 // ─── useAllocatorState ───────────────────────────────────────────────────────
 
@@ -205,7 +235,7 @@ export function useAllocatorState(): HookResult<AllocatorAccount> {
   const fetch = useCallback(async () => {
     try {
       const [pda] = getAllocatorPDA()
-      const info = await connection.getAccountInfo(pda)
+      const info = await deduplicatedGetAccountInfo(connection, pda)
       if (!mountedRef.current) return
 
       if (!info) {
@@ -257,7 +287,7 @@ export function useRiskVault(riskLevel: number): HookResult<RiskVaultAccount> {
   const fetch = useCallback(async () => {
     try {
       const [pda] = getRiskVaultPDA(riskLevel)
-      const info = await connection.getAccountInfo(pda)
+      const info = await deduplicatedGetAccountInfo(connection, pda)
       if (!mountedRef.current) return
 
       if (!info) {
@@ -320,7 +350,7 @@ export function useUserPosition(
     try {
       const [riskVault] = getRiskVaultPDA(riskLevel)
       const [pda] = getUserPositionPDA(publicKey, riskVault)
-      const info = await connection.getAccountInfo(pda)
+      const info = await deduplicatedGetAccountInfo(connection, pda)
       if (!mountedRef.current) return
 
       if (!info) {
@@ -538,7 +568,7 @@ export function useUsdcBalance(): HookResult<bigint> {
 
     try {
       const ata = await getAssociatedTokenAddress(USDC_MINT, publicKey)
-      const info = await connection.getAccountInfo(ata)
+      const info = await deduplicatedGetAccountInfo(connection, ata)
       if (!mountedRef.current) return
 
       if (!info) {

--- a/src/lib/error-reporting.ts
+++ b/src/lib/error-reporting.ts
@@ -1,0 +1,80 @@
+/**
+ * Error reporting module — foundation for Sentry integration.
+ *
+ * Currently logs to console with structured context. When NEXT_PUBLIC_SENTRY_DSN
+ * is set and @sentry/nextjs is installed, swap the console calls for
+ * Sentry.captureException / Sentry.captureMessage.
+ *
+ * SENTRY INTEGRATION CHECKLIST:
+ * 1. pnpm add @sentry/nextjs
+ * 2. npx @sentry/wizard@latest -i nextjs  (generates sentry.*.config.ts + next.config update)
+ * 3. Set NEXT_PUBLIC_SENTRY_DSN in .env.local and Vercel env vars
+ * 4. Replace console.error calls below with Sentry.captureException(error, { extra: context })
+ * 5. Remove the DSN guard — Sentry SDK handles missing DSN gracefully
+ */
+
+const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface ErrorContext {
+  /** Logical area of the app where the error occurred. */
+  domain?: 'rpc' | 'keeper-api' | 'transaction' | 'render' | 'unknown'
+  /** Any extra key-value pairs for debugging. */
+  extra?: Record<string, unknown>
+  /** User's wallet address if connected — helps correlate on-chain errors. */
+  user?: string
+}
+
+// ─── Core ────────────────────────────────────────────────────────────────────
+
+/**
+ * Report an error with optional context.
+ *
+ * In development: always logs to console.
+ * In production without DSN: logs to console (won't lose errors, just no aggregation).
+ * In production with DSN (once Sentry is wired): sends to Sentry.
+ */
+export function reportError(error: unknown, context: ErrorContext = {}): void {
+  const err = error instanceof Error ? error : new Error(String(error))
+  const { domain = 'unknown', extra, user } = context
+
+  if (process.env.NODE_ENV !== 'production' || !SENTRY_DSN) {
+    // Development / no-DSN: structured console output for traceability.
+    // eslint-disable-next-line no-console
+    console.error('[NanuqFi Error]', {
+      domain,
+      message: err.message,
+      stack: err.stack,
+      user,
+      ...extra,
+    })
+    return
+  }
+
+  // TODO: replace with Sentry.captureException after integration:
+  // Sentry.captureException(err, { extra: { domain, user, ...extra } })
+
+  // Fallback until Sentry is wired — never silently drop errors.
+  // eslint-disable-next-line no-console
+  console.error('[NanuqFi Error]', domain, err.message)
+}
+
+/**
+ * Report a non-fatal warning or informational event.
+ * Useful for keeper API degradation, stale data, or guardrail triggers.
+ */
+export function reportWarning(message: string, context: ErrorContext = {}): void {
+  const { domain = 'unknown', extra } = context
+
+  if (process.env.NODE_ENV !== 'production' || !SENTRY_DSN) {
+    // eslint-disable-next-line no-console
+    console.warn('[NanuqFi Warning]', { domain, message, ...extra })
+    return
+  }
+
+  // TODO: replace with Sentry.captureMessage after integration:
+  // Sentry.captureMessage(message, { level: 'warning', extra: { domain, ...extra } })
+  // eslint-disable-next-line no-console
+  console.warn('[NanuqFi Warning]', domain, message)
+}

--- a/src/lib/network-config.ts
+++ b/src/lib/network-config.ts
@@ -1,0 +1,72 @@
+/**
+ * Network configuration constants.
+ *
+ * All network-specific values are centralized here for easy mainnet migration.
+ *
+ * MAINNET MIGRATION CHECKLIST:
+ * 1. Set NEXT_PUBLIC_NETWORK=mainnet (or remove devnet-specific env vars)
+ * 2. Replace DEVNET_GENESIS_HASH with mainnet genesis hash:
+ *    '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d'
+ * 3. Replace DEVNET_RPC_FALLBACK with a mainnet RPC endpoint
+ * 4. Replace DEVNET_USDC_MINT with Circle's mainnet USDC:
+ *    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+ * 5. Replace DEVNET_PROGRAM_ID with mainnet-deployed allocator program
+ * 6. Update SOLSCAN_CLUSTER to 'mainnet-beta'
+ * 7. Remove or update the devnet onboarding guide in VaultDetailPage
+ * 8. Verify keeper API URL points to mainnet keeper
+ */
+
+// ─── Environment ──────────────────────────────────────────────────────────────
+
+/** Current network — controls UI labels and cluster params. */
+export const NETWORK = (process.env.NEXT_PUBLIC_NETWORK ?? 'devnet') as 'devnet' | 'mainnet'
+
+export const IS_DEVNET = NETWORK === 'devnet'
+
+// ─── RPC ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Devnet public RPC fallback — used if HELIUS_RPC_URL env is not set.
+ * MAINNET: replace with a mainnet RPC (Helius/Quicknode/Triton).
+ */
+export const DEVNET_RPC_FALLBACK = 'https://api.devnet.solana.com'
+
+// ─── Genesis Hashes ──────────────────────────────────────────────────────────
+
+/**
+ * Devnet genesis hash — stable canonical identifier for network detection.
+ * Source: getGenesisHash on https://api.devnet.solana.com
+ * MAINNET: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d'
+ */
+export const DEVNET_GENESIS_HASH = 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG'
+
+// ─── Program IDs & Addresses ──────────────────────────────────────────────────
+
+/**
+ * Allocator program ID — currently on devnet only.
+ * MAINNET: redeploy allocator, update to mainnet program ID.
+ * This is a display fallback — transactional code uses NEXT_PUBLIC_ALLOCATOR_PROGRAM_ID.
+ */
+export const DEVNET_PROGRAM_ID = '2QtJ5kmxLuW2jYCFpJMtzZ7PCnKdoMwkeueYoDUi5z5P'
+
+/**
+ * Test USDC mint (devnet) — minted by NanuqFi team, NOT Circle's devnet USDC.
+ * MAINNET: Circle's mainnet USDC = EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+ */
+export const DEVNET_USDC_MINT = 'BiTXT15XyfSakk5Yz8L8QrzHPWbK8NjoZeEMFrDvKdKh'
+
+// ─── Explorer URLs ────────────────────────────────────────────────────────────
+
+/**
+ * Solscan cluster query param for deep links.
+ * MAINNET: change to 'mainnet-beta'
+ */
+export const SOLSCAN_CLUSTER = 'devnet'
+
+export function solscanTxUrl(signature: string): string {
+  return `https://solscan.io/tx/${signature}?cluster=${SOLSCAN_CLUSTER}`
+}
+
+export function solscanAccountUrl(address: string): string {
+  return `https://solscan.io/account/${address}?cluster=${SOLSCAN_CLUSTER}`
+}

--- a/src/providers/solana-provider.tsx
+++ b/src/providers/solana-provider.tsx
@@ -6,16 +6,13 @@ import { WalletModalProvider } from '@solana/wallet-adapter-react-ui'
 import { PhantomWalletAdapter, SolflareWalletAdapter } from '@solana/wallet-adapter-wallets'
 
 import '@solana/wallet-adapter-react-ui/styles.css'
+import { DEVNET_GENESIS_HASH, DEVNET_RPC_FALLBACK } from '@/lib/network-config'
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const RPC_URL = typeof window !== 'undefined'
   ? `${window.location.origin}/api/rpc`
-  : (process.env.HELIUS_RPC_URL ?? 'https://api.devnet.solana.com')
-
-// Solana devnet genesis hash — stable, canonical identifier.
-// From: https://api.devnet.solana.com getGenesisHash
-const DEVNET_GENESIS_HASH = 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG'
+  : (process.env.HELIUS_RPC_URL ?? DEVNET_RPC_FALLBACK)
 
 // ─── Network Guard ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- #30 Fix broken /vaults /activity links (add /app prefix)
- #31 Mock data stale indicators
- #20 Remove unused imports
- #19 Bump Next.js → 16.1.7
- #17 Remove 8 unnecessary 'use client' directives
- #18 Centralize devnet references for mainnet migration
- #32 Add sitemap, robots.txt, OG meta tags
- #33 Reduce RPC polling + deduplicate calls
- #34 Add mobile nav + ARIA labels
- #35 Error reporting foundation

## Tests
- [x] 97 tests pass
- [x] pnpm build succeeds